### PR TITLE
[FwUpdateCfu] Update to VS2022 C++ toolset (v143)

### DIFF
--- a/Tools/ComponentFirmwareUpdateStandAloneToolSample/FwUpdateCfu.vcxproj
+++ b/Tools/ComponentFirmwareUpdateStandAloneToolSample/FwUpdateCfu.vcxproj
@@ -22,7 +22,7 @@
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{56F9617F-CFE6-4D6C-BFC6-08E593036A51}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <ProjectName>FwUpdateCfu</ProjectName>
   </PropertyGroup>
@@ -40,13 +40,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <DriverTargetPlatform>Universal</DriverTargetPlatform>
     <TargetVersion>


### PR DESCRIPTION
This is the only project in this repo with C++ toolset version specified. Also, change `WindowsTargetPlatformVersion` to be consistent with the other projects in this repo.