### PR TITLE
[CFUFirmwareSimulation] Remove DMF_CONFIG_VirtualHidDeviceVhf HidDescriptor(Length) assignment

### DIFF
--- a/Host/CFUFirmwareSimulation/sys/DmfInterface.c
+++ b/Host/CFUFirmwareSimulation/sys/DmfInterface.c
@@ -83,26 +83,6 @@ g_CfuVirtualHid_HidReportDescriptor[] =
     0xC0                                // END_COLLECTION()
 };
 
-// HID Device Descriptor to expose dmf PlatformPolicyManager as a virtual HID device.
-//
-static
-const
-HID_DESCRIPTOR
-g_CfuVirtualHid_HidDescriptor =
-{
-    0x09,     // Length of HID descriptor
-    0x21,     // Descriptor type == HID  0x21
-    0x0100,   // HID spec release
-    0x00,     // Country code == English
-    0x01,     // Number of HID class descriptors
-    {
-        0x22,   // Descriptor type
-        // Total length of report descriptor.
-        //
-        (USHORT) sizeof(g_CfuVirtualHid_HidReportDescriptor)
-    }
-};
-
 
 DRIVER_INITIALIZE DriverEntry;
 EVT_WDF_DRIVER_DEVICE_ADD CfuVirtualHidEvtDeviceAdd;
@@ -353,8 +333,6 @@ Return:
     virtualHidDeviceModuleConfig.ProductId = PRODUCT_ID;
     virtualHidDeviceModuleConfig.VersionNumber = 0x0001;
 
-    virtualHidDeviceModuleConfig.HidDescriptor = &g_CfuVirtualHid_HidDescriptor;
-    virtualHidDeviceModuleConfig.HidDescriptorLength = sizeof(g_CfuVirtualHid_HidDescriptor);
     virtualHidDeviceModuleConfig.HidReportDescriptor = g_CfuVirtualHid_HidReportDescriptor;
     virtualHidDeviceModuleConfig.HidReportDescriptorLength = sizeof(g_CfuVirtualHid_HidReportDescriptor);
 


### PR DESCRIPTION
Also, remove `g_CfuVirtualHid_HidDescriptor` that is no longer used anywhere. This is a compatibility change to become **compatible with more recent DMF versions** where these fields have been removed (see https://github.com/microsoft/DMF/pull/196). Please note that the `HidReportDescriptor(Length)` fields are still set. It's only the HID descriptor above that is removed.

The currently used version v1.1.29 of the DMF library sources doesn't seem to be using the `HidDescriptor(Length)` fields for anything. This is therefore basically dead code removal that shouldn't cause any problems with the current DMF version used.