### PR TITLE
[FwUpdateCfu] Fix failing HidD_SetOutputReport during FW update 

### DIFF
--- a/Tools/ComponentFirmwareUpdateStandAloneToolSample/FwUpdate.cpp
+++ b/Tools/ComponentFirmwareUpdateStandAloneToolSample/FwUpdate.cpp
@@ -382,7 +382,7 @@ Return Value:
 
     deviceWrite.hDevice = CreateFileW(
         DevicePath,
-        GENERIC_READ,
+        GENERIC_WRITE,
         FILE_SHARE_READ | FILE_SHARE_WRITE,
         NULL,
         OPEN_EXISTING,

--- a/Tools/ComponentFirmwareUpdateStandAloneToolSample/HidCommands.h
+++ b/Tools/ComponentFirmwareUpdateStandAloneToolSample/HidCommands.h
@@ -132,7 +132,8 @@ public:
         wprintf(L"HidD_SetOutputReport of reportId: %d length: %d\n", 
                 reportBuffer[0], reportLength);
 #endif
-        fSucceeded = HidD_SetOutputReport(Device.hDevice, reportBuffer, reportLength);
+        DWORD bytesWritten = 0;
+        fSucceeded = WriteFile(Device.hDevice, reportBuffer, reportLength, &bytesWritten, NULL);
         if (fSucceeded)
         {
 #if defined(_DEBUG)


### PR DESCRIPTION
Changes:
* Request GENERIC_WRITE access for `deviceWrite`.
* Change `HidCommands::SetOutputReport` to internally use `WriteFile` instead of `HidD_SetOutputReport
`

Done to fix problem of `HidD_SetOutputReport` calls failing with "The request is not supported" (0x32) errors.

According to [Sending HID reports](https://learn.microsoft.com/en-us/windows-hardware/drivers/hid/sending-hid-reports) then some HID devices doesn't support HidD_SetOutputReport. Clients then instead need to write output reports through WriteFile. CfuVirtualHid seems to be a such device.