### PR TITLE
[FwUpdateCfu] Remove unreferenced GetInputReport function

### DIFF
--- a/Tools/ComponentFirmwareUpdateStandAloneToolSample/HidCommands.h
+++ b/Tools/ComponentFirmwareUpdateStandAloneToolSample/HidCommands.h
@@ -147,23 +147,6 @@ public:
         return fSucceeded;
     }
 
-    static BOOL GetInputReport(
-        _In_ HID_DEVICE& Device,
-        _Out_ char* reportBuffer,
-        _In_ UINT32 reportLength)
-    {
-        BOOL fSucceeded = FALSE;
-
-        fSucceeded = HidD_GetInputReport(Device.hDevice, reportBuffer, reportLength);
-        if (!fSucceeded)
-        {
-            printf("error sending HidD_GetInputReport %d: %s\n", 
-                    GetLastError(), 
-                    GetLastErrorAsString().c_str());
-        }
-        return fSucceeded;
-    }
-
     static BOOL GetFeatureReport(
         _In_ HID_DEVICE& Device,
         _In_ USAGE UsagePage,


### PR DESCRIPTION
Proposing to delete dead code. The project currently uses `ReadFile` instead of `HidD_GetInputReport` for reading HID input reports, so there's no need for the `GetInputReport` function.

[Obtaining HID Reports](https://learn.microsoft.com/en-us/windows-hardware/drivers/hid/obtaining-hid-reports) documents that HID reports can either be obtained through HidD_GetInputReport or ReadFile.