### PR TITLE
Remove calls to DMF_Utility_EventLogEntryWriteUserMode that have been removed from the DMF library

### DIFF
--- a/Host/ComponentFirmwareUpdateDriver/DmfInterface.c
+++ b/Host/ComponentFirmwareUpdateDriver/DmfInterface.c
@@ -252,38 +252,6 @@ Return Value:
     ntStatus = DMF_ComponentFirmwareUpdate_Start(deviceContext->DmfModuleComponentFirmwareUpdate);
     if (!NT_SUCCESS(ntStatus))
     {
-        NTSTATUS ntStatus2;
-        WDFMEMORY deviceHardwareIdentifierMemory;
-        PWSTR deviceHardwareIdentifier;
-
-        // Get the Device's HardwareID.
-        //
-        deviceHardwareIdentifierMemory = WDF_NO_HANDLE;
-        deviceHardwareIdentifier = L"";
-        ntStatus2 = WdfDeviceAllocAndQueryProperty(device,
-                                                   DevicePropertyHardwareID, 
-                                                   PagedPool, 
-                                                   WDF_NO_OBJECT_ATTRIBUTES, 
-                                                   &deviceHardwareIdentifierMemory);
-        if (NT_SUCCESS(ntStatus2))
-        {
-            deviceHardwareIdentifier = (PWSTR) WdfMemoryGetBuffer(deviceHardwareIdentifierMemory,
-                                                                  NULL);
-        }
-
-        PWCHAR formatStrings[] = { L"HardwareId=%s", L"ntStatus=0x%x" };
-
-        // Report the failure in Event Log.
-        //
-        DMF_Utility_EventLogEntryWriteUserMode(EVENTLOG_PROVIDER_NAME,
-                                               EVENTLOG_ERROR_TYPE,
-                                               EVENTLOG_MESSAGE_PROTOCOL_START_FAIL,
-                                               ARRAYSIZE(formatStrings),
-                                               formatStrings,
-                                               ARRAYSIZE(formatStrings),
-                                               deviceHardwareIdentifier,
-                                               ntStatus);
-
         // Failure in starting the protocol is non-recoverable.
         // Report the failure to framework and let it attempt to restart the driver.
         // Note: This may result in banged out devnode.

--- a/Host/ComponentFirmwareUpdateDriver/Registry.c
+++ b/Host/ComponentFirmwareUpdateDriver/Registry.c
@@ -122,14 +122,6 @@ Return Value:
     //
     if (numberOfSubKeys == 0)
     {
-        // Report the warning in Event Log.
-        //
-        DMF_Utility_EventLogEntryWriteUserMode(EVENTLOG_PROVIDER_NAME,
-                                               EVENTLOG_WARNING_TYPE,
-                                               EVENTLOG_MESSAGE_NO_FIRMWARE_INFORMATION,
-                                               0,
-                                               NULL,
-                                               0);
         goto Exit;
     }
 
@@ -673,14 +665,6 @@ Return Value:
                     Device, 
                     ntStatus);
 
-        // Report the warning in Event Log.
-        //
-        DMF_Utility_EventLogEntryWriteUserMode(EVENTLOG_PROVIDER_NAME,
-                                               EVENTLOG_WARNING_TYPE,
-                                               EVENTLOG_MESSAGE_NO_PROTOCOL_OR_TRANSPORT_INFORMATION,
-                                               0,
-                                               NULL,
-                                               0);
         goto Exit;
     }
 


### PR DESCRIPTION
This is a compatibility change to become compatible with more recent DMF versions where the `DMF_Utility_EventLogEntryWriteUserMode` function have been removed (see https://github.com/microsoft/DMF/pull/121).

Please let me know the calls should instead be replaced by some other means of logging, and I'll do my best to update the PR accordingly.